### PR TITLE
NPM 배포 준비

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+test.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,18 @@
+# OSX
+.DS_Store
+
+# IDE
+.idea
+
+# npm
+node_modules
+package-lock.json
+
+# jest
+coverage
+
+# dev
+src
+
+#doc
+*.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# JSON Generator
+# Mockito
 
-Let's make json mock data easy!
+Let's make mock data easy!
 
 # Features
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MockPress
 
-Let's make mock data easy!
+Mock data generator, simple and flexible.
 
 # Features
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const personSchema = {
     `안녕하세요 제 이름은 ${current.name} 입니다!`,
   parents: {
     mother: {
-      name: mock.koreanName(),
+      name: mock.koreanName("female"),
     },
   },
   parentIntroduce: (current, loopIndex) =>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mockito
+# MockPress
 
 Let's make mock data easy!
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,23 @@
       "license": "ISC",
       "dependencies": {
         "nanoid": "^4.0.0"
+      },
+      "devDependencies": {
+        "rollup": "^3.2.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/nanoid": {
@@ -22,13 +39,45 @@
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
+    },
+    "node_modules/rollup": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.3.tgz",
+      "integrity": "sha512-qfadtkY5kl0F5e4dXVdj2D+GtOdifasXHFMiL1SMf9ADQDv5Eti6xReef9FKj+iQPR2pvtqWna57s/PjARY4fg==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
     }
   },
   "dependencies": {
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "nanoid": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
       "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
+    },
+    "rollup": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.2.3.tgz",
+      "integrity": "sha512-qfadtkY5kl0F5e4dXVdj2D+GtOdifasXHFMiL1SMf9ADQDv5Eti6xReef9FKj+iQPR2pvtqWna57s/PjARY4fg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "json-generator",
-  "version": "1.0.0",
+  "name": "mockito",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "json-generator",
-      "version": "1.0.0",
+      "name": "mockito",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
-        "nanoid": "^4.0.0"
+        "nanoid": "^3.3.4"
       },
       "devDependencies": {
         "rollup": "^3.2.3"
@@ -30,14 +30,14 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "bin": {
-        "nanoid": "bin/nanoid.js"
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/rollup": {
@@ -66,9 +66,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "rollup": {
       "version": "3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,19 @@
 {
-  "name": "mockito",
-  "version": "1.0.0",
+  "name": "js-mocker",
+  "version": "1.0.7",
   "description": "let's make mock data easy!",
   "sideEffects": false,
+  "type": "module",
   "exports": {
     ".": {
-      "require": "./dist/commonjs/bundle.js",
+      "require": "./dist/commonjs/bundle.cjs",
       "import": "./dist/esm/bundle.mjs"
     }
   },
   "main": "./dist/commonjs/bundle.js",
-  "type": "module",
   "scripts": {
-    "build": "rm -rf dist && rollup -c rollup.config.js"
+    "build": "rm -rf dist && rollup -c rollup.config.js",
+    "prepublish": "npm run build"
   },
   "keywords": [
     "json",
@@ -21,10 +22,14 @@
   ],
   "author": "",
   "license": "ISC",
-  "dependencies": {
-    "nanoid": "^4.0.0"
-  },
   "devDependencies": {
     "rollup": "^3.2.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/airman5573/json-generator.git"
+  },
+  "dependencies": {
+    "nanoid": "^3.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "js-mocker",
-  "version": "1.0.7",
+  "name": "mockpress",
+  "version": "1.0.0",
   "description": "let's make mock data easy!",
   "sideEffects": false,
   "type": "module",
@@ -27,7 +27,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/airman5573/json-generator.git"
+    "url": "https://github.com/airman5573/mockpress.git"
   },
   "dependencies": {
     "nanoid": "^3.3.4"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,18 @@
 {
   "name": "json-generator",
   "version": "1.0.0",
-  "description": "",
-  "main": "src/index.js",
+  "description": "let's make json mock data easy!",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "require": "./dist/commonjs/bundle.js",
+      "import": "./dist/esm/bundle.mjs"
+    }
+  },
+  "main": "main": "./dist/commonjs/bundle.js",
   "type": "module",
   "scripts": {
-    "generate": "node ./src/test.js"
+    "build": "rm -rf dist && rollup -c rollup.config.js"
   },
   "keywords": [
     "json",
@@ -16,5 +23,8 @@
   "license": "ISC",
   "dependencies": {
     "nanoid": "^4.0.0"
+  },
+  "devDependencies": {
+    "rollup": "^3.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "json-generator",
+  "name": "mockito",
   "version": "1.0.0",
-  "description": "let's make json mock data easy!",
+  "description": "let's make mock data easy!",
   "sideEffects": false,
   "exports": {
     ".": {
@@ -9,7 +9,7 @@
       "import": "./dist/esm/bundle.mjs"
     }
   },
-  "main": "main": "./dist/commonjs/bundle.js",
+  "main": "./dist/commonjs/bundle.js",
   "type": "module",
   "scripts": {
     "build": "rm -rf dist && rollup -c rollup.config.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mockpress",
-  "version": "1.0.0",
-  "description": "let's make mock data easy!",
+  "version": "0.1.0",
+  "description": "Mock data generator, simple and flexible.",
   "sideEffects": false,
   "type": "module",
   "exports": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ export default [
     input: "./src/index.js",
     output: {
       format: "cjs",
-      file: "./dist/commonjs/bundle.js",
+      file: "./dist/commonjs/bundle.cjs",
       sourcemap: true,
     },
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,18 @@
+export default [
+  {
+    input: "./src/index.js",
+    output: {
+      format: "cjs",
+      file: "./dist/commonjs/bundle.js",
+      sourcemap: true,
+    },
+  },
+  {
+    input: "./src/index.js",
+    output: {
+      format: "es",
+      file: "./dist/esm/bundle.mjs",
+      sourcemap: true,
+    },
+  },
+];

--- a/src/sample.js
+++ b/src/sample.js
@@ -8,7 +8,7 @@ const personSchema = {
     `안녕하세요 제 이름은 ${current.name} 입니다!`,
   parents: {
     mother: {
-      name: mock.koreanName(),
+      name: mock.koreanName("female"),
     },
   },
   parentIntroduce: (current, loopIndex) =>

--- a/src/test.js
+++ b/src/test.js
@@ -2,28 +2,25 @@ import { mock, generate } from "./index.js";
 
 const personSchema = {
   id: mock.autoIncrement(),
+  index: (current, loopIndex) => `${loopIndex + 1} 번째 Object`,
   name: mock.koreanName(),
   introduce: (current, loopIndex) =>
     `안녕하세요 제 이름은 ${current.name} 입니다!`,
   parents: {
-    motherName: mock.koreanName("female"),
+    mother: {
+      name: mock.koreanName(),
+    },
   },
   parentIntroduce: (current, loopIndex) =>
-    `저희 어머니는 ${current.parents.motherName}입니다!`,
-  userName: mock.text(),
+    `저희 어머니 성함은 ${current.parents.mother.name} 입니다!`,
   profileImage: mock.image(200, 200),
   age: mock.integer(10, 20),
   address: mock.koreanAddress(),
   hobby: {
     id: mock.autoIncrement(),
     cost: mock.money(1000, 10000, 100),
-    userName: (current, loopIndex) => `${current.name} - ${loopIndex}`,
-    secondName: {
-      mySecondAge: (current, loopIndex) => current.age + loopIndex,
-    },
   },
-  hobbyCost: (current, loopIndex) => current.hobby.cost + loopIndex,
 };
 
-const result = generate(personSchema);
+const result = generate(personSchema, 2);
 console.dir(result, { depth: null });


### PR DESCRIPTION
1. rollup setting : cjs, esm 둘다 지원합니다.
2. d.ts 가 없는 관계로 아직 typescript는 지원하지 않습니다.

nanoid를 4.0 -> 3.4로 downgrade 했습니다.  
4.0부터는 cjs 를 지원하지 않기 때문입니다.